### PR TITLE
chore: update the version of the API

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Update Snyk
         run: |
-          curl --location --request PATCH 'https://api.snyk.io/v3/orgs/${{ secrets.SNYK_ORG_PUBLIC_ID }}/settings/iac/?version=2021-11-03~beta' \
+          curl --location --request PATCH 'https://api.snyk.io/v3/orgs/${{ secrets.SNYK_ORG_PUBLIC_ID }}/settings/iac/?version=2021-12-09' \
           --header 'Content-Type: application/vnd.api+json' \
           --header 'Authorization: token ${{ secrets.SNYK_TOKEN }}' \
           --data-raw '{


### PR DESCRIPTION
This version of the API has long sunset (it is still callable but returns `sunset` in the `snyk-version-served` header). We are the only org still using this version, so before removing it completely we are updating the call to the GA version.